### PR TITLE
Refactor key handlers with OOP

### DIFF
--- a/spec/Autocomplete.spec.jsx
+++ b/spec/Autocomplete.spec.jsx
@@ -1,0 +1,167 @@
+import React from 'react'
+import { shallow } from 'enzyme'
+import expect, { createSpy } from 'expect'
+
+import Autocomplete from '../src/Autocomplete'
+
+describe('<Autocomplete />', () => {
+  describe('.considerNext()', () => {
+    context('when considering a suggestion', () => {
+      const [beer, beerNuts] = [{
+        label: 'beer',
+        value: 'beer'
+      }, {
+        label: 'beer nuts',
+        value: 'beer nuts'
+      }]
+
+      const props = {
+        input: 'be',
+        consider: createSpy(),
+        considering: beer,
+        tags: [beer, beerNuts],
+        renderNewOption: createSpy()
+      }
+
+      const wrapper = shallow(
+        <Autocomplete {...props} />
+      )
+
+      wrapper.instance().considerNext()
+
+      it('considers the next suggestion', () => {
+        expect(props.consider).toHaveBeenCalledWith(beerNuts)
+      })
+    })
+
+    context('when not considering anything', () => {
+      const tag = { label: 'beer', value: 'beer' }
+      const props = {
+        input: 'be',
+        consider: createSpy(),
+        tags: [tag],
+        renderNewOption: createSpy()
+      }
+
+      const wrapper = shallow(
+        <Autocomplete {...props} />
+      )
+
+      wrapper.instance().considerNext()
+
+      it('considers the first suggestion', () => {
+        expect(props.consider).toHaveBeenCalledWith(tag)
+      })
+    })
+  })
+
+  describe('.considerPrevious()', () => {
+    context('when considering the first suggestion', () => {
+      const tag = { label: 'beer', value: 'beer' }
+      const props = {
+        input: 'be',
+        consider: createSpy(),
+        considering: tag,
+        tags: [tag],
+        renderNewOption: createSpy()
+      }
+
+      const wrapper = shallow(
+        <Autocomplete {...props} />
+      )
+
+      wrapper.instance().considerPrevious()
+
+      it('clears the suggestion', () => {
+        expect(props.consider).toHaveBeenCalledWith(null)
+      })
+    })
+
+    context('when considering any other suggestion', () => {
+      const [beer, beerNuts] = [{
+        label: 'beer',
+        value: 'beer'
+      }, {
+        label: 'beer nuts',
+        value: 'beer nuts'
+      }]
+
+      const props = {
+        input: 'be',
+        consider: createSpy(),
+        considering: beerNuts,
+        tags: [beer, beerNuts],
+        renderNewOption: createSpy()
+      }
+
+      const wrapper = shallow(
+        <Autocomplete {...props} />
+      )
+
+      wrapper.instance().considerPrevious()
+
+      it('considers the previous suggestion', () => {
+        expect(props.consider).toHaveBeenCalledWith(beer)
+      })
+    })
+  })
+
+  describe('.componentWillReceiveProps', () => {
+    context('when the input is cleared', () => {
+      const props = {
+        input: 'b',
+        consider: createSpy(),
+        renderNewOption: createSpy(),
+        tags: []
+      }
+
+      const wrapper = shallow(
+        <Autocomplete {...props} />
+      )
+
+      wrapper.instance().componentWillReceiveProps({ ...props, input: '' })
+
+      it('clears the active suggestion', () => {
+        expect(props.consider).toHaveBeenCalledWith(null)
+      })
+    })
+
+    context('when there are suggestions', () => {
+      const tag = { label: 'beer', value: 'beer' }
+      const props = {
+        consider: createSpy(),
+        renderNewOption: createSpy(),
+        tags: [tag]
+      }
+
+      const wrapper = shallow(
+        <Autocomplete {...props} />
+      )
+
+      wrapper.instance().componentWillReceiveProps({ ...props, input: 'be' })
+
+      it('considers the first suggestion', () => {
+        expect(props.consider).toHaveBeenCalledWith(tag)
+      })
+    })
+
+    context('when there are no suggestions', () => {
+      const tag = { label: 'beer', value: 'beer' }
+      const props = {
+        consider: createSpy(),
+        renderNewOption: createSpy(),
+        tags: [tag]
+      }
+
+      const wrapper = shallow(
+        <Autocomplete {...props} />
+      )
+
+      wrapper.instance().componentWillReceiveProps({ ...props, input: 'whi' })
+
+      it('clears the active suggestion', () => {
+        expect(props.consider).toHaveBeenCalledWith(null)
+      })
+    })
+  })
+})

--- a/spec/TagManager.spec.js
+++ b/spec/TagManager.spec.js
@@ -1,0 +1,187 @@
+import expect, { createSpy } from 'expect'
+import TagManager from '../src/TagManager'
+
+function setup(tagBox = {}) {
+  const event = {
+    preventDefault: createSpy()
+  }
+
+  return { tagManager: new TagManager(event, tagBox), tagBox }
+}
+
+describe('TagManager', () => {
+  describe('.prev()', () => {
+    context('when there are no suggestions', () => {
+      const { tagManager, tagBox } = setup({
+        state: {
+          considering: null
+        },
+        autocomplete: {
+          considerPrevious: createSpy()
+        }
+      })
+
+      tagManager.prev()
+
+      it('does not try to consider the previous suggestion', () => {
+        expect(tagBox.autocomplete.considerPrevious).toNotHaveBeenCalled()
+      })
+    })
+
+    context('when considering a suggestion', () => {
+      const { tagManager, tagBox } = setup({
+        state: {
+          considering: { label: 'beer', value: 'beer' }
+        },
+        autocomplete: {
+          considerPrevious: createSpy()
+        }
+      })
+
+      tagManager.prev()
+
+      it('considers the previous suggestion', () => {
+        expect(tagBox.autocomplete.considerPrevious).toHaveBeenCalled()
+      })
+    })
+  })
+
+  describe('.next()', () => {
+    it('considers the next option', () => {
+      const { tagManager, tagBox } = setup({
+        autocomplete: {
+          considerNext: createSpy()
+        }
+      })
+
+      tagManager.next()
+
+      expect(tagBox.autocomplete.considerNext).toHaveBeenCalled()
+    })
+  })
+
+  describe('.create()', () => {
+    context('when considering a suggestion', () => {
+      const { tagManager, tagBox } = setup({
+        state: {
+          considering: { label: 'beer', value: 'beer' }
+        },
+        select: createSpy()
+      })
+
+      tagManager.create()
+
+      it('selects the suggestion being considered', () => {
+        expect(tagBox.select).toHaveBeenCalledWith(tagBox.state.considering)
+      })
+    })
+
+    context('when not considering a suggestion', () => {
+      context('if the tag is in the suggestion list', () => {
+        const tag = { label: 'beer', value: 'beer' }
+        const { tagManager, tagBox } = setup({
+          state: {
+            tag: 'beer'
+          },
+          props: {
+            tags: [tag]
+          },
+          select: createSpy()
+        })
+
+        tagManager.create()
+
+        it('selects from the suggestion list', () => {
+          expect(tagBox.select).toHaveBeenCalledWith(tag)
+        })
+      })
+
+      context('if the tag is not in the suggestion list', () => {
+        const tag = { label: 'beer', value: 'beer' }
+        const { tagManager, tagBox } = setup({
+          state: {
+            tag: 'whiskey'
+          },
+          props: {
+            tags: [tag]
+          },
+          createTag: createSpy()
+        })
+
+        tagManager.create()
+
+        it('submits a new tag', () => {
+          expect(tagBox.createTag).toHaveBeenCalled()
+        })
+      })
+    })
+  })
+
+  describe('.select()', () => {
+    context('when there is input', () => {
+      context('when considering a suggestion', () => {
+        const { tagManager, tagBox } = setup({
+          state: {
+            tag: 'whis',
+            considering: { label: 'whiskey', value: 'whiskey' }
+          },
+          select: createSpy()
+        })
+
+        tagManager.select()
+
+        it('selects the suggestion being considered', () => {
+          expect(tagBox.select).toHaveBeenCalledWith(tagBox.state.considering)
+        })
+      })
+
+      context('when not considering a suggestion', () => {
+        const { tagManager, tagBox } = setup({
+          state: {
+            tag: 'whiskey'
+          },
+          createTag: createSpy()
+        })
+
+        tagManager.select()
+
+        it('submits a new tag', () => {
+          expect(tagBox.createTag).toHaveBeenCalled()
+        })
+      })
+    })
+  })
+
+  describe('.clear()', () => {
+    it('clears the input and the suggestion', () => {
+      const { tagManager, tagBox } = setup({
+        setState: createSpy()
+      })
+
+      tagManager.clear()
+
+      expect(tagBox.setState).toHaveBeenCalledWith({ tag: '', considering: null })
+    })
+  })
+
+  describe('.deleteLast()', () => {
+    context('when there is no input', () => {
+      context('when backspace deletion is on', () => {
+        const tag = { label: 'beer', value: 'beer' }
+        const { tagManager, tagBox } = setup({
+          props: {
+            backspaceDelete: true,
+            selected: [tag],
+            removeTag: createSpy()
+          }
+        })
+
+        tagManager.deleteLast()
+
+        it('removes the last tag', () => {
+          expect(tagBox.props.removeTag).toHaveBeenCalledWith(tag)
+        })
+      })
+    })
+  })
+})

--- a/src/TagBox.jsx
+++ b/src/TagBox.jsx
@@ -4,6 +4,7 @@ import drive from './driver'
 import TAG_REJECTED from './constants'
 import TagProp from './utils'
 import Tag from './Tag'
+import TagManager from './TagManager'
 
 export default class TagBox extends Component {
   static propTypes = {
@@ -63,20 +64,8 @@ export default class TagBox extends Component {
 
   keyHandler() {
     return e => {
-      const { tags, selected, removeTag, backspaceDelete } = this.props
-      const action = drive(e, {
-        tag: this.state.tag,
-        tags,
-        selected,
-        backspaceDelete,
-        remove: removeTag,
-        create: () => this.createTag(),
-        next: () => this.autocomplete.considerNext(),
-        prev: () => this.autocomplete.considerPrevious(),
-        select: (tag) => this.select(tag),
-        clear: () => this.setState({ tag: '', considering: null }),
-        considering: this.state.considering
-      })
+      const tagManager = new TagManager(e, this)
+      const action = drive(e.which, tagManager)
 
       if (action) {
         action()

--- a/src/TagManager.js
+++ b/src/TagManager.js
@@ -1,0 +1,69 @@
+export default class TagManager {
+  constructor(e, tagBox) {
+    this.event = e
+    this.tagBox = tagBox
+    this.tagBoxData = { ...tagBox.props, ...tagBox.state }
+  }
+
+  execute(action) {
+    this.event.preventDefault()
+    action()
+  }
+
+  prev() {
+    if (this.tagBoxData.considering) {
+      this.execute(() => this.tagBox.autocomplete.considerPrevious())
+    }
+  }
+
+  next() {
+    this.execute(() => this.tagBox.autocomplete.considerNext())
+  }
+
+  create() {
+    const { considering, tags, tag } = this.tagBoxData
+
+    this.execute(() => {
+      if (considering) {
+        this.tagBox.select(considering)
+      } else {
+        const existingTag = tags.find(t => t.label === tag)
+        if (existingTag) {
+          this.tagBox.select(existingTag)
+        } else {
+          this.tagBox.createTag()
+        }
+      }
+    })
+  }
+
+  select() {
+    const { considering, tag } = this.tagBoxData
+
+    this.execute(() => {
+      if (tag) {
+        if (considering) {
+          this.tagBox.select(considering)
+        } else {
+          this.tagBox.createTag()
+        }
+      }
+    })
+  }
+
+  clear() {
+    this.execute(() => this.tagBox.setState({ tag: '', considering: null }))
+  }
+
+  deleteLast() {
+    const { selected, tag, backspaceDelete, removeTag } = this.tagBoxData
+
+    if (tag || !backspaceDelete) {
+      return
+    }
+
+    this.execute(() => {
+      removeTag(selected[selected.length - 1])
+    })
+  }
+}

--- a/src/driver.js
+++ b/src/driver.js
@@ -7,74 +7,19 @@ const TAB = 9
 const ESC = 27
 const BKSPC = 8
 
-export default function drive(event, tagManager) {
-  const next = () => {
-    event.preventDefault()
-    tagManager.next()
-  }
-
-  const prev = () => {
-    if (tagManager.considering) {
-      event.preventDefault()
-      tagManager.prev()
-    }
-  }
-
-  const create = () => {
-    event.preventDefault()
-    const { tag, tags, create: createTag, select, considering } = tagManager
-    if (considering) {
-      select(considering)
-    } else {
-      const existingTag = tags.find(t => t.label === tag)
-      if (existingTag) {
-        select(existingTag)
-      } else {
-        createTag()
-      }
-    }
-  }
-
-  const select = () => {
-    const { considering, select: selectTag, tag, create: createTag } = tagManager
-
-    if (tag) {
-      event.preventDefault()
-
-      if (considering) {
-        selectTag(considering)
-      } else {
-        createTag()
-      }
-    }
-  }
-
-  const clear = () => {
-    event.preventDefault()
-    tagManager.clear()
-  }
-
-  const deleteLast = () => {
-    const { selected, tag, backspaceDelete, remove } = tagManager
-
-    if (tag || !backspaceDelete) {
-      return
-    }
-
-    event.preventDefault()
-    remove(selected.reverse()[0])
-  }
+export default function drive(which, tagManager) {
+  const execute = action => () => action.apply(tagManager)
 
   const eventMap = {
-    [ENTER]: create,
-    [RIGHT]: next,
-    [DOWN]: next,
-    [UP]: prev,
-    [LEFT]: prev,
-    [TAB]: select,
-    [ESC]: clear,
-    [BKSPC]: deleteLast
+    [ENTER]: execute(tagManager.create),
+    [RIGHT]: execute(tagManager.next),
+    [DOWN]: execute(tagManager.next),
+    [UP]: execute(tagManager.prev),
+    [LEFT]: execute(tagManager.prev),
+    [TAB]: execute(tagManager.select),
+    [ESC]: execute(tagManager.clear),
+    [BKSPC]: execute(tagManager.deleteLast)
   }
 
-  return eventMap[event.which]
+  return eventMap[which]
 }


### PR DESCRIPTION
Need an objective opinion as to whether or not this is an improvement. The goals were:

1. Reduce the `drive` function to a simple mapping from keycode to action
2. DRY/abstract calls to `event.preventDefault()`
3. Get a good handle on context and reduce the number of anonymous functions

~~I don't think I accomplished the 3rd point very well.~~ Second commit accomplishes this better than the first. Open to suggestions for improving it further.